### PR TITLE
add support for newInstancesProtectedFromScaleIn in AWSMachinePool v1…

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -825,6 +825,9 @@ spec:
                       type: object
                     type: array
                 type: object
+              newInstancesProtectedFromScaleIn:
+                description: Enable or disable instance scale-in protection
+                type: boolean
               providerID:
                 description: ProviderID is the ARN of the associated ASG
                 type: string

--- a/docs/book/src/crd/index.md
+++ b/docs/book/src/crd/index.md
@@ -20799,6 +20799,18 @@ SuspendProcessesTypes
 If a process is removed from this list it will automatically be resumed.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>newInstancesProtectedFromScaleIn</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Enable or disable instance scale-in protection</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -21040,6 +21052,18 @@ SuspendProcessesTypes
 <td>
 <p>SuspendProcesses defines a list of processes to suspend for the given ASG. This is constantly reconciled.
 If a process is removed from this list it will automatically be resumed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>newInstancesProtectedFromScaleIn</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Enable or disable instance scale-in protection</p>
 </td>
 </tr>
 </tbody>
@@ -22015,6 +22039,16 @@ Kubernetes meta/v1.Duration
 <tr>
 <td>
 <code>capacityRebalance</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>newInstancesProtectedFromScaleIn</code><br/>
 <em>
 bool
 </em>

--- a/exp/api/v1beta1/conversion.go
+++ b/exp/api/v1beta1/conversion.go
@@ -38,6 +38,7 @@ func (src *AWSMachinePool) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 
+	dst.Spec.NewInstancesProtectedFromScaleIn = restored.Spec.NewInstancesProtectedFromScaleIn
 	if restored.Spec.SuspendProcesses != nil {
 		dst.Spec.SuspendProcesses = restored.Spec.SuspendProcesses
 	}

--- a/exp/api/v1beta1/zz_generated.conversion.go
+++ b/exp/api/v1beta1/zz_generated.conversion.go
@@ -557,6 +557,7 @@ func autoConvert_v1beta2_AWSMachinePoolSpec_To_v1beta1_AWSMachinePoolSpec(in *v1
 	}
 	out.CapacityRebalance = in.CapacityRebalance
 	// WARNING: in.SuspendProcesses requires manual conversion: does not exist in peer-type
+	// WARNING: in.NewInstancesProtectedFromScaleIn requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -796,6 +797,7 @@ func autoConvert_v1beta2_AutoScalingGroup_To_v1beta1_AutoScalingGroup(in *v1beta
 	out.Subnets = *(*[]string)(unsafe.Pointer(&in.Subnets))
 	out.DefaultCoolDown = in.DefaultCoolDown
 	out.CapacityRebalance = in.CapacityRebalance
+	// WARNING: in.NewInstancesProtectedFromScaleIn requires manual conversion: does not exist in peer-type
 	out.MixedInstancesPolicy = (*MixedInstancesPolicy)(unsafe.Pointer(in.MixedInstancesPolicy))
 	out.Status = ASGStatus(in.Status)
 	out.Instances = *(*[]apiv1beta2.Instance)(unsafe.Pointer(&in.Instances))

--- a/exp/api/v1beta2/awsmachinepool_types.go
+++ b/exp/api/v1beta2/awsmachinepool_types.go
@@ -94,6 +94,10 @@ type AWSMachinePoolSpec struct {
 	// SuspendProcesses defines a list of processes to suspend for the given ASG. This is constantly reconciled.
 	// If a process is removed from this list it will automatically be resumed.
 	SuspendProcesses *SuspendProcessesTypes `json:"suspendProcesses,omitempty"`
+
+	// Enable or disable instance scale-in protection
+	// +optional
+	NewInstancesProtectedFromScaleIn bool `json:"newInstancesProtectedFromScaleIn,omitempty"`
 }
 
 // SuspendProcessesTypes contains user friendly auto-completable values for suspended process names.

--- a/exp/api/v1beta2/types.go
+++ b/exp/api/v1beta2/types.go
@@ -195,16 +195,17 @@ type Tags map[string]string
 // AutoScalingGroup describes an AWS autoscaling group.
 type AutoScalingGroup struct {
 	// The tags associated with the instance.
-	ID                string          `json:"id,omitempty"`
-	Tags              infrav1.Tags    `json:"tags,omitempty"`
-	Name              string          `json:"name,omitempty"`
-	DesiredCapacity   *int32          `json:"desiredCapacity,omitempty"`
-	MaxSize           int32           `json:"maxSize,omitempty"`
-	MinSize           int32           `json:"minSize,omitempty"`
-	PlacementGroup    string          `json:"placementGroup,omitempty"`
-	Subnets           []string        `json:"subnets,omitempty"`
-	DefaultCoolDown   metav1.Duration `json:"defaultCoolDown,omitempty"`
-	CapacityRebalance bool            `json:"capacityRebalance,omitempty"`
+	ID                               string          `json:"id,omitempty"`
+	Tags                             infrav1.Tags    `json:"tags,omitempty"`
+	Name                             string          `json:"name,omitempty"`
+	DesiredCapacity                  *int32          `json:"desiredCapacity,omitempty"`
+	MaxSize                          int32           `json:"maxSize,omitempty"`
+	MinSize                          int32           `json:"minSize,omitempty"`
+	PlacementGroup                   string          `json:"placementGroup,omitempty"`
+	Subnets                          []string        `json:"subnets,omitempty"`
+	DefaultCoolDown                  metav1.Duration `json:"defaultCoolDown,omitempty"`
+	CapacityRebalance                bool            `json:"capacityRebalance,omitempty"`
+	NewInstancesProtectedFromScaleIn bool            `json:"newInstancesProtectedFromScaleIn,omitempty"`
 
 	MixedInstancesPolicy      *MixedInstancesPolicy `json:"mixedInstancesPolicy,omitempty"`
 	Status                    ASGStatus

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -524,6 +524,7 @@ func diffASG(machinePoolScope *scope.MachinePoolScope, existingASG *expinfrav1.A
 	detectedAWSMachinePoolSpec.MaxSize = existingASG.MaxSize
 	detectedAWSMachinePoolSpec.MinSize = existingASG.MinSize
 	detectedAWSMachinePoolSpec.CapacityRebalance = existingASG.CapacityRebalance
+	detectedAWSMachinePoolSpec.NewInstancesProtectedFromScaleIn = existingASG.NewInstancesProtectedFromScaleIn
 	{
 		mixedInstancesPolicy := machinePoolScope.AWSMachinePool.Spec.MixedInstancesPolicy
 		// InstancesDistribution is optional, and the default values come from AWS, so

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -869,6 +869,32 @@ func TestDiffASG(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "newInstancesProtectedFromScaleIn != asg.newInstancesProtectedFromScaleIn",
+			args: args{
+				machinePoolScope: &scope.MachinePoolScope{
+					MachinePool: &expclusterv1.MachinePool{
+						Spec: expclusterv1.MachinePoolSpec{
+							Replicas: pointer.Int32(1),
+						},
+					},
+					AWSMachinePool: &expinfrav1.AWSMachinePool{
+						Spec: expinfrav1.AWSMachinePoolSpec{
+							MaxSize:                          2,
+							MinSize:                          0,
+							NewInstancesProtectedFromScaleIn: false,
+						},
+					},
+				},
+				existingASG: &expinfrav1.AutoScalingGroup{
+					DesiredCapacity:                  pointer.Int32(1),
+					MaxSize:                          2,
+					MinSize:                          0,
+					NewInstancesProtectedFromScaleIn: true,
+				},
+			},
+			want: true,
+		},
+		{
 			name: "all matches",
 			args: args{
 				machinePoolScope: &scope.MachinePoolScope{
@@ -879,9 +905,10 @@ func TestDiffASG(t *testing.T) {
 					},
 					AWSMachinePool: &expinfrav1.AWSMachinePool{
 						Spec: expinfrav1.AWSMachinePoolSpec{
-							MaxSize:           2,
-							MinSize:           0,
-							CapacityRebalance: true,
+							MaxSize:                          2,
+							MinSize:                          0,
+							CapacityRebalance:                true,
+							NewInstancesProtectedFromScaleIn: false,
 							MixedInstancesPolicy: &expinfrav1.MixedInstancesPolicy{
 								InstancesDistribution: &expinfrav1.InstancesDistribution{
 									OnDemandAllocationStrategy: expinfrav1.OnDemandAllocationStrategyPrioritized,
@@ -892,10 +919,11 @@ func TestDiffASG(t *testing.T) {
 					},
 				},
 				existingASG: &expinfrav1.AutoScalingGroup{
-					DesiredCapacity:   pointer.Int32(1),
-					MaxSize:           2,
-					MinSize:           0,
-					CapacityRebalance: true,
+					DesiredCapacity:                  pointer.Int32(1),
+					MaxSize:                          2,
+					MinSize:                          0,
+					CapacityRebalance:                true,
+					NewInstancesProtectedFromScaleIn: false,
 					MixedInstancesPolicy: &expinfrav1.MixedInstancesPolicy{
 						InstancesDistribution: &expinfrav1.InstancesDistribution{
 							OnDemandAllocationStrategy: expinfrav1.OnDemandAllocationStrategyPrioritized,

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -42,10 +42,11 @@ func (s *Service) SDKToAutoScalingGroup(v *autoscaling.Group) (*expinfrav1.AutoS
 		ID:   aws.StringValue(v.AutoScalingGroupARN),
 		Name: aws.StringValue(v.AutoScalingGroupName),
 		// TODO(rudoi): this is just terrible
-		DesiredCapacity:   aws.Int32(int32(aws.Int64Value(v.DesiredCapacity))),
-		MaxSize:           int32(aws.Int64Value(v.MaxSize)),
-		MinSize:           int32(aws.Int64Value(v.MinSize)),
-		CapacityRebalance: aws.BoolValue(v.CapacityRebalance),
+		DesiredCapacity:                  aws.Int32(int32(aws.Int64Value(v.DesiredCapacity))),
+		MaxSize:                          int32(aws.Int64Value(v.MaxSize)),
+		MinSize:                          int32(aws.Int64Value(v.MinSize)),
+		CapacityRebalance:                aws.BoolValue(v.CapacityRebalance),
+		NewInstancesProtectedFromScaleIn: aws.BoolValue(v.NewInstancesProtectedFromScaleIn),
 		//TODO: determine what additional values go here and what else should be in the struct
 	}
 
@@ -161,13 +162,14 @@ func (s *Service) CreateASG(machinePoolScope *scope.MachinePoolScope) (*expinfra
 	}
 
 	input := &expinfrav1.AutoScalingGroup{
-		Name:                 machinePoolScope.Name(),
-		MaxSize:              machinePoolScope.AWSMachinePool.Spec.MaxSize,
-		MinSize:              machinePoolScope.AWSMachinePool.Spec.MinSize,
-		Subnets:              subnets,
-		DefaultCoolDown:      machinePoolScope.AWSMachinePool.Spec.DefaultCoolDown,
-		CapacityRebalance:    machinePoolScope.AWSMachinePool.Spec.CapacityRebalance,
-		MixedInstancesPolicy: machinePoolScope.AWSMachinePool.Spec.MixedInstancesPolicy,
+		Name:                             machinePoolScope.Name(),
+		MaxSize:                          machinePoolScope.AWSMachinePool.Spec.MaxSize,
+		MinSize:                          machinePoolScope.AWSMachinePool.Spec.MinSize,
+		Subnets:                          subnets,
+		DefaultCoolDown:                  machinePoolScope.AWSMachinePool.Spec.DefaultCoolDown,
+		CapacityRebalance:                machinePoolScope.AWSMachinePool.Spec.CapacityRebalance,
+		MixedInstancesPolicy:             machinePoolScope.AWSMachinePool.Spec.MixedInstancesPolicy,
+		NewInstancesProtectedFromScaleIn: machinePoolScope.AWSMachinePool.Spec.NewInstancesProtectedFromScaleIn,
 	}
 
 	// Default value of MachinePool replicas set by CAPI is 1.
@@ -215,12 +217,13 @@ func (s *Service) CreateASG(machinePoolScope *scope.MachinePoolScope) (*expinfra
 
 func (s *Service) runPool(i *expinfrav1.AutoScalingGroup, launchTemplateID string) error {
 	input := &autoscaling.CreateAutoScalingGroupInput{
-		AutoScalingGroupName: aws.String(i.Name),
-		MaxSize:              aws.Int64(int64(i.MaxSize)),
-		MinSize:              aws.Int64(int64(i.MinSize)),
-		VPCZoneIdentifier:    aws.String(strings.Join(i.Subnets, ", ")),
-		DefaultCooldown:      aws.Int64(int64(i.DefaultCoolDown.Duration.Seconds())),
-		CapacityRebalance:    aws.Bool(i.CapacityRebalance),
+		AutoScalingGroupName:             aws.String(i.Name),
+		MaxSize:                          aws.Int64(int64(i.MaxSize)),
+		MinSize:                          aws.Int64(int64(i.MinSize)),
+		VPCZoneIdentifier:                aws.String(strings.Join(i.Subnets, ", ")),
+		DefaultCooldown:                  aws.Int64(int64(i.DefaultCoolDown.Duration.Seconds())),
+		CapacityRebalance:                aws.Bool(i.CapacityRebalance),
+		NewInstancesProtectedFromScaleIn: aws.Bool(i.NewInstancesProtectedFromScaleIn),
 	}
 
 	if i.DesiredCapacity != nil {
@@ -291,11 +294,12 @@ func (s *Service) UpdateASG(scope *scope.MachinePoolScope) error {
 	}
 
 	input := &autoscaling.UpdateAutoScalingGroupInput{
-		AutoScalingGroupName: aws.String(scope.Name()), //TODO: define dynamically - borrow logic from ec2
-		MaxSize:              aws.Int64(int64(scope.AWSMachinePool.Spec.MaxSize)),
-		MinSize:              aws.Int64(int64(scope.AWSMachinePool.Spec.MinSize)),
-		VPCZoneIdentifier:    aws.String(strings.Join(subnetIDs, ",")),
-		CapacityRebalance:    aws.Bool(scope.AWSMachinePool.Spec.CapacityRebalance),
+		AutoScalingGroupName:             aws.String(scope.Name()), //TODO: define dynamically - borrow logic from ec2
+		MaxSize:                          aws.Int64(int64(scope.AWSMachinePool.Spec.MaxSize)),
+		MinSize:                          aws.Int64(int64(scope.AWSMachinePool.Spec.MinSize)),
+		VPCZoneIdentifier:                aws.String(strings.Join(subnetIDs, ",")),
+		CapacityRebalance:                aws.Bool(scope.AWSMachinePool.Spec.CapacityRebalance),
+		NewInstancesProtectedFromScaleIn: aws.Bool(scope.AWSMachinePool.Spec.NewInstancesProtectedFromScaleIn),
 	}
 
 	if scope.MachinePool.Spec.Replicas != nil {

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -141,12 +141,13 @@ func TestServiceSDKToAutoScalingGroup(t *testing.T) {
 		{
 			name: "valid input - all required fields filled",
 			input: &autoscaling.Group{
-				AutoScalingGroupARN:  aws.String("test-id"),
-				AutoScalingGroupName: aws.String("test-name"),
-				DesiredCapacity:      aws.Int64(1234),
-				MaxSize:              aws.Int64(1234),
-				MinSize:              aws.Int64(1234),
-				CapacityRebalance:    aws.Bool(true),
+				AutoScalingGroupARN:              aws.String("test-id"),
+				AutoScalingGroupName:             aws.String("test-name"),
+				DesiredCapacity:                  aws.Int64(1234),
+				MaxSize:                          aws.Int64(1234),
+				MinSize:                          aws.Int64(1234),
+				CapacityRebalance:                aws.Bool(true),
+				NewInstancesProtectedFromScaleIn: aws.Bool(true),
 				MixedInstancesPolicy: &autoscaling.MixedInstancesPolicy{
 					InstancesDistribution: &autoscaling.InstancesDistribution{
 						OnDemandAllocationStrategy:          aws.String("prioritized"),
@@ -165,12 +166,13 @@ func TestServiceSDKToAutoScalingGroup(t *testing.T) {
 				},
 			},
 			want: &expinfrav1.AutoScalingGroup{
-				ID:                "test-id",
-				Name:              "test-name",
-				DesiredCapacity:   aws.Int32(1234),
-				MaxSize:           int32(1234),
-				MinSize:           int32(1234),
-				CapacityRebalance: true,
+				ID:                               "test-id",
+				Name:                             "test-name",
+				DesiredCapacity:                  aws.Int32(1234),
+				MaxSize:                          int32(1234),
+				MinSize:                          int32(1234),
+				CapacityRebalance:                true,
+				NewInstancesProtectedFromScaleIn: true,
 				MixedInstancesPolicy: &expinfrav1.MixedInstancesPolicy{
 					InstancesDistribution: &expinfrav1.InstancesDistribution{
 						OnDemandAllocationStrategy:          expinfrav1.OnDemandAllocationStrategyPrioritized,
@@ -211,12 +213,13 @@ func TestServiceSDKToAutoScalingGroup(t *testing.T) {
 		{
 			name: "valid input - all fields filled",
 			input: &autoscaling.Group{
-				AutoScalingGroupARN:  aws.String("test-id"),
-				AutoScalingGroupName: aws.String("test-name"),
-				DesiredCapacity:      aws.Int64(1234),
-				MaxSize:              aws.Int64(1234),
-				MinSize:              aws.Int64(1234),
-				CapacityRebalance:    aws.Bool(true),
+				AutoScalingGroupARN:              aws.String("test-id"),
+				AutoScalingGroupName:             aws.String("test-name"),
+				DesiredCapacity:                  aws.Int64(1234),
+				MaxSize:                          aws.Int64(1234),
+				MinSize:                          aws.Int64(1234),
+				CapacityRebalance:                aws.Bool(true),
+				NewInstancesProtectedFromScaleIn: aws.Bool(true),
 				MixedInstancesPolicy: &autoscaling.MixedInstancesPolicy{
 					InstancesDistribution: &autoscaling.InstancesDistribution{
 						OnDemandAllocationStrategy:          aws.String("prioritized"),
@@ -249,12 +252,13 @@ func TestServiceSDKToAutoScalingGroup(t *testing.T) {
 				},
 			},
 			want: &expinfrav1.AutoScalingGroup{
-				ID:                "test-id",
-				Name:              "test-name",
-				DesiredCapacity:   aws.Int32(1234),
-				MaxSize:           int32(1234),
-				MinSize:           int32(1234),
-				CapacityRebalance: true,
+				ID:                               "test-id",
+				Name:                             "test-name",
+				DesiredCapacity:                  aws.Int32(1234),
+				MaxSize:                          int32(1234),
+				MinSize:                          int32(1234),
+				CapacityRebalance:                true,
+				NewInstancesProtectedFromScaleIn: true,
 				MixedInstancesPolicy: &expinfrav1.MixedInstancesPolicy{
 					InstancesDistribution: &expinfrav1.InstancesDistribution{
 						OnDemandAllocationStrategy:          expinfrav1.OnDemandAllocationStrategyPrioritized,
@@ -285,34 +289,37 @@ func TestServiceSDKToAutoScalingGroup(t *testing.T) {
 		{
 			name: "valid input - without mixedInstancesPolicy",
 			input: &autoscaling.Group{
-				AutoScalingGroupARN:  aws.String("test-id"),
-				AutoScalingGroupName: aws.String("test-name"),
-				DesiredCapacity:      aws.Int64(1234),
-				MaxSize:              aws.Int64(1234),
-				MinSize:              aws.Int64(1234),
-				CapacityRebalance:    aws.Bool(true),
-				MixedInstancesPolicy: nil,
+				AutoScalingGroupARN:              aws.String("test-id"),
+				AutoScalingGroupName:             aws.String("test-name"),
+				DesiredCapacity:                  aws.Int64(1234),
+				MaxSize:                          aws.Int64(1234),
+				MinSize:                          aws.Int64(1234),
+				CapacityRebalance:                aws.Bool(true),
+				NewInstancesProtectedFromScaleIn: aws.Bool(true),
+				MixedInstancesPolicy:             nil,
 			},
 			want: &expinfrav1.AutoScalingGroup{
-				ID:                   "test-id",
-				Name:                 "test-name",
-				DesiredCapacity:      aws.Int32(1234),
-				MaxSize:              int32(1234),
-				MinSize:              int32(1234),
-				CapacityRebalance:    true,
-				MixedInstancesPolicy: nil,
+				ID:                               "test-id",
+				Name:                             "test-name",
+				DesiredCapacity:                  aws.Int32(1234),
+				MaxSize:                          int32(1234),
+				MinSize:                          int32(1234),
+				CapacityRebalance:                true,
+				NewInstancesProtectedFromScaleIn: true,
+				MixedInstancesPolicy:             nil,
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalid input - incorrect on-demand allocation strategy",
 			input: &autoscaling.Group{
-				AutoScalingGroupARN:  aws.String("test-id"),
-				AutoScalingGroupName: aws.String("test-name"),
-				DesiredCapacity:      aws.Int64(1234),
-				MaxSize:              aws.Int64(1234),
-				MinSize:              aws.Int64(1234),
-				CapacityRebalance:    aws.Bool(true),
+				AutoScalingGroupARN:              aws.String("test-id"),
+				AutoScalingGroupName:             aws.String("test-name"),
+				DesiredCapacity:                  aws.Int64(1234),
+				MaxSize:                          aws.Int64(1234),
+				MinSize:                          aws.Int64(1234),
+				CapacityRebalance:                aws.Bool(true),
+				NewInstancesProtectedFromScaleIn: aws.Bool(true),
 				MixedInstancesPolicy: &autoscaling.MixedInstancesPolicy{
 					InstancesDistribution: &autoscaling.InstancesDistribution{
 						OnDemandAllocationStrategy:          aws.String("prioritized"),
@@ -335,12 +342,13 @@ func TestServiceSDKToAutoScalingGroup(t *testing.T) {
 		{
 			name: "invalid input - incorrect spot allocation strategy",
 			input: &autoscaling.Group{
-				AutoScalingGroupARN:  aws.String("test-id"),
-				AutoScalingGroupName: aws.String("test-name"),
-				DesiredCapacity:      aws.Int64(1234),
-				MaxSize:              aws.Int64(1234),
-				MinSize:              aws.Int64(1234),
-				CapacityRebalance:    aws.Bool(true),
+				AutoScalingGroupARN:              aws.String("test-id"),
+				AutoScalingGroupName:             aws.String("test-name"),
+				DesiredCapacity:                  aws.Int64(1234),
+				MaxSize:                          aws.Int64(1234),
+				MinSize:                          aws.Int64(1234),
+				CapacityRebalance:                aws.Bool(true),
+				NewInstancesProtectedFromScaleIn: aws.Bool(true),
 				MixedInstancesPolicy: &autoscaling.MixedInstancesPolicy{
 					InstancesDistribution: &autoscaling.InstancesDistribution{
 						OnDemandAllocationStrategy:          aws.String("prioritized"),
@@ -487,9 +495,10 @@ func TestServiceCreateASG(t *testing.T) {
 			wantASG:               false,
 			expect: func(m *mock_autoscalingiface.MockAutoScalingAPIMockRecorder) {
 				expected := &autoscaling.CreateAutoScalingGroupInput{
-					AutoScalingGroupName: aws.String("create-asg-success"),
-					CapacityRebalance:    aws.Bool(false),
-					DefaultCooldown:      aws.Int64(0),
+					AutoScalingGroupName:             aws.String("create-asg-success"),
+					CapacityRebalance:                aws.Bool(false),
+					NewInstancesProtectedFromScaleIn: aws.Bool(false),
+					DefaultCooldown:                  aws.Int64(0),
 					MixedInstancesPolicy: &autoscaling.MixedInstancesPolicy{
 						InstancesDistribution: &autoscaling.InstancesDistribution{
 							OnDemandAllocationStrategy:          aws.String("prioritized"),


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Fixes upstream https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2635

Add support for scale-in protection for kind AWSMachinePool on v1beta2 for release 2.3


